### PR TITLE
Sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ venv
 project.db
 
 djangocms/media/*
+
+# django-sass-processor will compile css into this folder
+# TODO configure another folder?
+djangocms/static

--- a/djangocms/fablab_website/settings.py
+++ b/djangocms/fablab_website/settings.py
@@ -124,6 +124,7 @@ INSTALLED_APPS = (
     'menus',
     'sekizai',
     'treebeard',
+    'sass_processor',
     'djangocms_text_ckeditor',
     'djangocms_style',
     'djangocms_column',

--- a/djangocms/fablab_website/templates/base.html
+++ b/djangocms/fablab_website/templates/base.html
@@ -1,4 +1,4 @@
-{% load cms_tags staticfiles sekizai_tags menu_tags %}
+{% load cms_tags staticfiles sekizai_tags menu_tags sass_tags %}
 <!doctype html>
 <html>
 	<head>
@@ -6,7 +6,7 @@
 		<title>{% block title %}FAU FabLab{% endblock title %}</title>
 		<meta name="viewport" content="width=device-width,initial-scale=1">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.4/css/bootstrap.min.css">
-		<link rel="stylesheet" href="/static/css/fablab/fablab-bootstrap-theme.css">
+		<link rel="stylesheet" href="{% sass_src 'css/fablab/fablab-bootstrap-theme.scss' %}">
 		{% render_block "css" %}
 		{% include "favicon.html" %}
 	</head>

--- a/djangocms/requirements.txt
+++ b/djangocms/requirements.txt
@@ -21,3 +21,7 @@ html5lib
 Pillow>=2.3
 django-sekizai>=0.7
 six
+
+django-compressor>=1.6
+django-sass-processor>=0.3.0
+libsass>=0.9.3

--- a/djangocms/requirements.txt
+++ b/djangocms/requirements.txt
@@ -23,5 +23,8 @@ django-sekizai>=0.7
 six
 
 django-compressor>=1.6
-django-sass-processor>=0.3.0
+# this one is currently broken: django-sass-processor>=0.3.0
+# but the pr to fix it is already accepted: https://github.com/jrief/django-sass-processor/pull/21
+# here is a fixed version:
+https://github.com/sedrubal/django-sass-processor/archive/0.3.0-python3-hotfix.tar.gz
 libsass>=0.9.3


### PR DESCRIPTION
- Using https://github.com/jrief/django-sass-processor
- There is a issue with the pypi package, see:
  jrief/django-sass-processor # 20
  so we temporary have to use this patched version: https://github.com/sedrubal/django-sass-processor/releases/tag/0.3.0-python3-hotfix
- If we don't want to use it, we can simply go back to css
- Using a SASS processor has the effort that one can simply hack the
  scss and instantly see the changes without compiling it manually
